### PR TITLE
feat(data): add data ingestion & preprocessing pipeline

### DIFF
--- a/notebooks/01_EDA.ipynb
+++ b/notebooks/01_EDA.ipynb
@@ -1,0 +1,402 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# %% [markdown]\n",
+    "# # Task 01 — Exploratory Data Analysis (EDA)\n",
+    "#\n",
+    "# **Project:** KAIM Quant Forecast & Portfolio Optimization 2025  \n",
+    "# **Notebook:** 01_EDA.ipynb  \n",
+    "# **Purpose:** Load processed TSLA, BND, SPY daily data (2015-07-01 → 2025-07-31), perform statistical & visual EDA as per brief.  \n",
+    "# **Author:** [Your Name]\n",
+    "#\n",
+    "# ---\n",
+    "#\n",
+    "# ## Objectives (from project brief)\n",
+    "# - Check data quality (types, missing values, date alignment)\n",
+    "# - Compute descriptive stats (mean, volatility, skew, kurtosis)\n",
+    "# - Plot time series for adjusted close, returns, rolling volatility\n",
+    "# - Detect & quantify outliers in returns\n",
+    "# - Run Augmented Dickey-Fuller tests for stationarity\n",
+    "# - Compute risk metrics: historical VaR, Sharpe ratio\n",
+    "# - Document insights for each plot/test (investment-relevant interpretation)\n",
+    "#\n",
+    "# ## Why this matters:\n",
+    "# EDA is **decision insurance** — before modeling, we need to be sure our data is valid, aligned, and that we understand statistical properties that will affect forecasts and portfolio construction.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %%\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns\n",
+    "from pathlib import Path\n",
+    "from statsmodels.tsa.stattools import adfuller\n",
+    "from scipy.stats import skew, kurtosis\n",
+    "\n",
+    "plt.style.use('seaborn-v0_8-darkgrid')\n",
+    "sns.set_context('talk')\n",
+    "\n",
+    "PROC_DIR = Path(\"../data/processed\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# %% [markdown]\n",
+    "# ## 2. Load processed data\n",
+    "# Data comes from `src/data/preprocess.py` — aligned on business days, with `*_adj` and `*_ret` columns.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %%\n",
+    "df = pd.read_csv(PROC_DIR / \"combined_adj_and_returns.csv\", index_col=0, parse_dates=True)\n",
+    "df.head()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# %% [markdown]\n",
+    "# **Insight:**  \n",
+    "# - Columns: `TSLA_adj`, `TSLA_ret`, `BND_adj`, `BND_ret`, `SPY_adj`, `SPY_ret`  \n",
+    "# - Frequency: business days.  \n",
+    "# - Return columns are simple daily returns.  \n",
+    "# - Price columns will be used for plotting long-term trends; return columns for volatility & risk metrics.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %%\n",
+    "missing_counts = df.isna().sum()\n",
+    "dtypes = df.dtypes\n",
+    "date_min, date_max = df.index.min(), df.index.max()\n",
+    "\n",
+    "print(\"Missing values:\\n\", missing_counts)\n",
+    "print(\"\\nData types:\\n\", dtypes)\n",
+    "print(f\"\\nDate range: {date_min} → {date_max}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# %% [markdown]\n",
+    "# **Elite insight:**  \n",
+    "# - Any persistent NaNs in returns after preprocessing suggest corporate actions or missing market data — would require forward/backward fill decisions.  \n",
+    "# - Date alignment ensures covariance matrix in portfolio step is valid.  \n",
+    "# - Non-float types in price/returns columns would break model fitting.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %%\n",
+    "desc_stats = {}\n",
+    "for ticker in [\"TSLA\", \"BND\", \"SPY\"]:\n",
+    "    ret = df[f\"{ticker}_ret\"].dropna()\n",
+    "    desc_stats[ticker] = {\n",
+    "        \"mean_daily\": ret.mean(),\n",
+    "        \"ann_mean\": ret.mean()*252,\n",
+    "        \"std_daily\": ret.std(),\n",
+    "        \"ann_vol\": ret.std()*np.sqrt(252),\n",
+    "        \"skew\": skew(ret),\n",
+    "        \"kurtosis\": kurtosis(ret, fisher=True)\n",
+    "    }\n",
+    "\n",
+    "pd.DataFrame(desc_stats).T\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# %% [markdown]\n",
+    "# **Elite insight:**  \n",
+    "# - TSLA expected to have higher annualized volatility (>50%) vs BND (<10%).  \n",
+    "# - Skew/kurtosis tell us about fat tails & asymmetry — TSLA typically shows positive skew but heavy tails (kurtosis >> 3).  \n",
+    "# - BND’s low vol and near-normal distribution is bond-typical.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# %% [markdown]\n",
+    "# ## 5. Price series plots\n",
+    "# Visual inspection of price trends.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %%\n",
+    "fig, ax = plt.subplots(3, 1, figsize=(14, 12), sharex=True)\n",
+    "for i, ticker in enumerate([\"TSLA\", \"BND\", \"SPY\"]):\n",
+    "    ax[i].plot(df.index, df[f\"{ticker}_adj\"], label=f\"{ticker} Adj Close\")\n",
+    "    ax[i].set_title(f\"{ticker} Adjusted Close Price\")\n",
+    "    ax[i].legend()\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# %% [markdown]\n",
+    "# **Elite insight:**  \n",
+    "# - TSLA shows explosive growth periods & sharp drawdowns — relevant for model non-stationarity.  \n",
+    "# - BND stable, mean-reverting range; SPY upward trend with crises visible (e.g., COVID, 2022 rate hikes).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# %% [markdown]\n",
+    "# ## 6. Returns distribution\n",
+    "# Histograms + KDE for each asset’s daily returns.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %% [markdown]\n",
+    "# ## 7. Rolling volatility (30-day annualized)\n",
+    "# Helps identify regime changes in risk.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %%\n",
+    "window = 30\n",
+    "fig, ax = plt.subplots(3, 1, figsize=(14, 12), sharex=True)\n",
+    "for i, ticker in enumerate([\"TSLA\", \"BND\", \"SPY\"]):\n",
+    "    vol = df[f\"{ticker}_ret\"].rolling(window).std()*np.sqrt(252)\n",
+    "    ax[i].plot(vol, label=f\"{ticker} 30-day Annualized Vol\")\n",
+    "    ax[i].set_title(f\"{ticker} Rolling Volatility ({window} days)\")\n",
+    "    ax[i].legend()\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# %% [markdown]\n",
+    "# **Elite insight:**  \n",
+    "# - Volatility clusters — high vol persists; models may benefit from GARCH-like terms.  \n",
+    "# - TSLA volatility spikes align with market stress and company events (e.g., earnings).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# %% [markdown]\n",
+    "# ## 8. Outlier detection\n",
+    "# Identify top 5 absolute daily returns for each asset.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %%\n",
+    "outliers = {}\n",
+    "for ticker in [\"TSLA\", \"BND\", \"SPY\"]:\n",
+    "    abs_ret = df[f\"{ticker}_ret\"].abs()\n",
+    "    top5 = abs_ret.sort_values(ascending=False).head(5)\n",
+    "    outliers[ticker] = df.loc[top5.index, [f\"{ticker}_ret\"]]\n",
+    "\n",
+    "outliers\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# %% [markdown]\n",
+    "# **Elite insight:**  \n",
+    "# Outliers are often linked to macro events (Fed announcements, pandemics) or idiosyncratic shocks (TSLA earnings).  \n",
+    "# They influence VaR & model training; consider robust estimators.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# %% [markdown]\n",
+    "# ## 9. Augmented Dickey-Fuller (ADF) tests\n",
+    "# Test for stationarity in prices and returns.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %%\n",
+    "def adf_test(series):\n",
+    "    res = adfuller(series.dropna(), autolag='AIC')\n",
+    "    return {\"ADF Stat\": res[0], \"p-value\": res[1], \"# Lags\": res[2], \"# Observations\": res[3]}\n",
+    "\n",
+    "adf_results = {}\n",
+    "for ticker in [\"TSLA\", \"BND\", \"SPY\"]:\n",
+    "    adf_results[f\"{ticker}_price\"] = adf_test(df[f\"{ticker}_adj\"])\n",
+    "    adf_results[f\"{ticker}_return\"] = adf_test(df[f\"{ticker}_ret\"])\n",
+    "\n",
+    "pd.DataFrame(adf_results).T\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# %% [markdown]\n",
+    "# **Elite insight:**  \n",
+    "# - Price series p-values > 0.05 → fail to reject unit root → non-stationary (expected).  \n",
+    "# - Return series p-values < 0.05 → reject unit root → stationary (required for ARIMA without extra differencing).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# %% [markdown]\n",
+    "# ## 10. Risk metrics — VaR & Sharpe\n",
+    "# Value at Risk (5%) and annualized Sharpe ratio for each asset.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %%\n",
+    "def var_historic(returns, level=0.05):\n",
+    "    return np.percentile(returns.dropna(), 100*level)\n",
+    "\n",
+    "def sharpe_ratio(returns, risk_free=0.0):\n",
+    "    ann_ret = returns.mean()*252\n",
+    "    ann_vol = returns.std()*np.sqrt(252)\n",
+    "    return (ann_ret - risk_free) / ann_vol\n",
+    "\n",
+    "risk_metrics = {}\n",
+    "for ticker in [\"TSLA\", \"BND\", \"SPY\"]:\n",
+    "    ret = df[f\"{ticker}_ret\"]\n",
+    "    risk_metrics[ticker] = {\n",
+    "        \"VaR_5%\": var_historic(ret, 0.05),\n",
+    "        \"Sharpe\": sharpe_ratio(ret)\n",
+    "    }\n",
+    "\n",
+    "pd.DataFrame(risk_metrics).T\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# %% [markdown]\n",
+    "# **Elite insight:**  \n",
+    "# - TSLA’s VaR (5%) may be several times larger than BND’s — risk budgeting must account for position sizing.  \n",
+    "# - Sharpe >1 for SPY historically — robust core holding; TSLA’s Sharpe depends heavily on time period.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %% [markdown]\n",
+    "# ## 11. Summary Table for Memo\n",
+    "# Consolidate key metrics into one table for the Investment Memo appendix.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %%\n",
+    "summary_df = pd.concat([\n",
+    "    pd.DataFrame(desc_stats).T[[\"ann_mean\", \"ann_vol\"]],\n",
+    "    pd.DataFrame(risk_metrics).T\n",
+    "], axis=1)\n",
+    "summary_df.to_csv(\"../reports/EDA_summary_metrics.csv\")\n",
+    "summary_df\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# %% [markdown]\n",
+    "# **Elite insight:**  \n",
+    "# - This table can be inserted directly into the Investment Memo appendix.  \n",
+    "# - For portfolio optimization, `ann_mean` and `ann_vol` provide intuition, but expected returns for TSLA will come from forecast model (Task 4).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# %% [markdown]\n",
+    "# ## 12. Next steps (from EDA to modeling)\n",
+    "# - Confirm returns stationarity for ARIMA.  \n",
+    "# - Consider volatility modeling (GARCH) if volatility clustering is strong.  \n",
+    "# - Remove/flag outliers if they unduly influence model fit.  \n",
+    "# - Proceed to Task 2 modeling with cleaned returns & prices.\n",
+    "#\n",
+    "# **EDA complete.**\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/data/fetch_data.py
+++ b/src/data/fetch_data.py
@@ -1,0 +1,34 @@
+# src/data/fetch_data.py
+import yfinance as yf
+import pandas as pd
+from pathlib import Path
+import argparse
+import logging
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
+
+TICKERS = ["TSLA", "BND", "SPY"]
+RAW_DIR = Path("data/raw")
+RAW_DIR.mkdir(parents=True, exist_ok=True)
+
+def fetch_save(ticker, start="2015-07-01", end="2025-07-31"):
+    logging.info(f"Fetching {ticker} from {start} to {end}")
+    df = yf.download(ticker, start=start, end=end, progress=False)
+    if df.empty:
+        logging.error(f"No data for {ticker} — check yfinance and ticker name.")
+        return
+    df.index = pd.to_datetime(df.index)
+    df.to_csv(RAW_DIR / f"{ticker}.csv")
+    logging.info(f"Saved {RAW_DIR / f'{ticker}.csv'} (rows={len(df)})")
+    return df
+
+def main(args):
+    for t in TICKERS:
+        fetch_save(t, start=args.start, end=args.end)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--start", default="2015-07-01")
+    parser.add_argument("--end", default="2025-07-31")
+    args = parser.parse_args()
+    main(args)

--- a/src/data/preprocess.py
+++ b/src/data/preprocess.py
@@ -1,0 +1,109 @@
+# src/data/preprocess.py
+import pandas as pd
+import numpy as np
+from pathlib import Path
+from statsmodels.tsa.stattools import adfuller
+import logging
+import argparse
+
+RAW_DIR = Path("data/raw")
+PROC_DIR = Path("data/processed")
+PROC_DIR.mkdir(parents=True, exist_ok=True)
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
+
+def load_csv(ticker):
+    df = pd.read_csv(RAW_DIR / f"{ticker}.csv", index_col=0, parse_dates=True)
+    return df
+
+def reindex_business(df, start=None, end=None):
+    idx = pd.date_range(start=start or df.index.min(), end=end or df.index.max(), freq='B')  # business days
+    df = df.reindex(idx)
+    return df
+
+def compute_basic_features(df):
+    df = df.copy()
+    # Ensure numeric types
+    for col in ["Open","High","Low","Close","Adj Close","Volume"]:
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors='coerce')
+    # Ffill prices, zero fill volume
+    df[["Open","High","Low","Close","Adj Close"]] = df[["Open","High","Low","Close","Adj Close"]].ffill()
+    df["Volume"] = df["Volume"].fillna(0)
+    # Daily returns
+    df["ret"] = df["Adj Close"].pct_change()
+    # log-returns for modeling if needed
+    df["log_ret"] = np.log1p(df["ret"])
+    # rolling vol (30-day)
+    df["vol_30"] = df["ret"].rolling(window=30).std() * np.sqrt(252)  # annualized
+    # rolling mean for trend
+    df["ma_50"] = df["Adj Close"].rolling(50).mean()
+    df["ma_200"] = df["Adj Close"].rolling(200).mean()
+    return df
+
+def adf_test(series, name):
+    series = series.dropna()
+    if len(series) < 10:
+        return {"adf_stat": np.nan, "pvalue": np.nan}
+    res = adfuller(series, autolag='AIC')
+    return {"adf_stat": res[0], "pvalue": res[1], "n_lags": res[2], "n_obs": res[3]}
+
+def var_historic(returns, level=0.05):
+    returns = returns.dropna()
+    if returns.empty:
+        return np.nan
+    return np.percentile(returns, 100 * level)
+
+def sharpe_ratio(returns, risk_free=0.0):
+    r = returns.dropna()
+    if r.empty:
+        return np.nan
+    ann_ret = r.mean() * 252
+    ann_vol = r.std() * np.sqrt(252)
+    if ann_vol == 0:
+        return np.nan
+    return (ann_ret - risk_free) / ann_vol
+
+def process_ticker(ticker, start=None, end=None):
+    logging.info("Processing %s", ticker)
+    df = load_csv(ticker)
+    df = reindex_business(df, start=start, end=end)
+    df = compute_basic_features(df)
+    # missing check
+    missing = df.isna().sum()
+    logging.info("Missing values for %s:\n%s", ticker, missing.to_dict())
+    # ADF tests
+    adf_close = adf_test(df["Adj Close"], ticker + " Adj Close")
+    adf_ret = adf_test(df["ret"], ticker + " returns")
+    stats = {
+        "adf_close": adf_close,
+        "adf_ret": adf_ret,
+        "var_5pct": var_historic(df["ret"], 0.05),
+        "sharpe": sharpe_ratio(df["ret"])
+    }
+    logging.info("Stats for %s: %s", ticker, stats)
+    df.to_csv(PROC_DIR / f"{ticker}_processed.csv")
+    return df, stats
+
+def main(args):
+    all_stats = {}
+    for t in ["TSLA","BND","SPY"]:
+        df, stats = process_ticker(t, start=args.start, end=args.end)
+        all_stats[t] = stats
+    # save a combined dataset for merging price series (Adj Close)
+    dfs = []
+    for t in ["TSLA","BND","SPY"]:
+        df = pd.read_csv(PROC_DIR / f"{t}_processed.csv", index_col=0, parse_dates=True)
+        dfs.append(df[["Adj Close","ret"]].rename(columns={"Adj Close": f"{t}_adj", "ret": f"{t}_ret"}))
+    combined = pd.concat(dfs, axis=1)
+    combined.to_csv(PROC_DIR / "combined_adj_and_returns.csv")
+    logging.info("Saved combined processed data.")
+    # store stats
+    pd.DataFrame.from_dict({k: {"adf_close_p": v["adf_close"]["pvalue"], "adf_ret_p": v["adf_ret"]["pvalue"], "var_5pct": v["var_5pct"], "sharpe": v["sharpe"]} for k,v in all_stats.items()}, orient='index').to_csv(PROC_DIR / "summary_stats.csv")
+    logging.info("Done.")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--start", default="2015-07-01")
+    parser.add_argument("--end", default="2025-07-31")
+    args = parser.parse_args()
+    main(args)


### PR DESCRIPTION
What: yfinance fetch, business-day reindex, forward-fill pricing, compute daily & log returns, rolling (30d) vol, VaR, Sharpe, and ADF stationarity tests. Produces data/processed/combined_adj_and_returns.csv.

Why: Establishes a single authoritative dataset and automated diagnostics before modeling. Ensures reproducibility and early detection of data issues.

How tested: run 'python src/data/fetch_data.py' then 'python src/data/preprocess.py' and confirm data/processed/combined_adj_and_returns.csv contains TSLA_adj, SPY_adj and BND_adj.