### PR TITLE
feat(data): add data ingestion & preprocessing pipeline

### DIFF
--- a/src/data/fetch_data.py
+++ b/src/data/fetch_data.py
@@ -11,16 +11,47 @@ TICKERS = ["TSLA", "BND", "SPY"]
 RAW_DIR = Path("data/raw")
 RAW_DIR.mkdir(parents=True, exist_ok=True)
 
-def fetch_save(ticker, start="2015-07-01", end="2025-07-31"):
+import time
+
+def fetch_save(ticker, start="2015-07-01", end="2025-07-31", retries=3, delay=5):
     logging.info(f"Fetching {ticker} from {start} to {end}")
-    df = yf.download(ticker, start=start, end=end, progress=False)
-    if df.empty:
-        logging.error(f"No data for {ticker} — check yfinance and ticker name.")
-        return
-    df.index = pd.to_datetime(df.index)
-    df.to_csv(RAW_DIR / f"{ticker}.csv")
-    logging.info(f"Saved {RAW_DIR / f'{ticker}.csv'} (rows={len(df)})")
-    return df
+    for attempt in range(1, retries + 1):
+        try:
+            # Increase timeout from default to 60s
+            df = yf.download(
+                ticker,
+                start=start,
+                end=end,
+                progress=False,
+                auto_adjust=False,
+                timeout=60
+            )
+            if df.empty:
+                raise ValueError(f"No data returned for {ticker}")
+            df.index = pd.to_datetime(df.index)
+            df.index.name = "Date"
+
+            expected_cols = ["Open", "High", "Low", "Close", "Adj Close", "Volume"]
+            for col in expected_cols:
+                if col not in df.columns:
+                    logging.warning(f"{ticker}: Missing expected column {col} — will fill with NaN")
+                    df[col] = pd.NA
+            df = df[expected_cols]
+
+            out_path = RAW_DIR / f"{ticker}.csv"
+            df.to_csv(out_path, index=True)
+            logging.info(f"Saved clean CSV to {out_path} (rows={len(df)})")
+            return df
+
+        except Exception as e:
+            logging.error(f"Attempt {attempt} failed for {ticker}: {e}")
+            if attempt < retries:
+                logging.info(f"Retrying in {delay} seconds...")
+                time.sleep(delay)
+            else:
+                logging.error(f"All {retries} attempts failed for {ticker}.")
+                return None
+
 
 def main(args):
     for t in TICKERS:


### PR DESCRIPTION
What: yfinance fetch, business-day reindex, forward-fill pricing, compute daily & log returns, rolling (30d) vol, VaR, Sharpe, and ADF stationarity tests. Produces data/processed/combined_adj_and_returns.csv.

Why: Establishes a single authoritative dataset and automated diagnostics before modeling. Ensures reproducibility and early detection of data issues.

How tested: run 'python src/data/fetch_data.py' then 'python src/data/preprocess.py' and confirm data/processed/combined_adj_and_returns.csv contains TSLA_adj, SPY_adj and BND_adj.